### PR TITLE
FE-779 Spell checking workflow for PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: yarn

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,0 +1,25 @@
+name: Test deployment
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  spellcheck:
+    name: Spell Check on changed doc files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files in the docs folder
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v44
+        with:
+          files: docs/**
+          separator: '\n'
+      - name: Spell check if any file(s) in the docs folder change
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
+        run: |
+          echo $ALL_CHANGED_FILES | yarn spellcheck-on-pr

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -10,8 +10,8 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: yarn

--- a/package.json
+++ b/package.json
@@ -1,40 +1,41 @@
 {
-    "name": "docs",
-    "version": "0.1.1",
-    "private": true,
-    "scripts": {
-        "docusaurus": "docusaurus",
-        "start": "docusaurus start",
-        "build": "docusaurus build",
-        "swizzle": "docusaurus swizzle",
-        "deploy": "docusaurus deploy",
-        "serve": "docusaurus serve",
-        "spellcheck": "cspell \"docs/**\" --show-suggestions"
-    },
-    "dependencies": {
-        "@cmfcmf/docusaurus-search-local": "^1.1.0",
-        "@docusaurus/core": "^3.1.1",
-        "@docusaurus/preset-classic": "^3.1.1",
-        "@mdx-js/react": "^3.0.1",
-        "clsx": "^2.1.0",
-        "cspell": "^8.6.1",
-        "docusaurus-lunr-search": "^3.3.2",
-        "dotenv": "^16.4.5",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "yarn": "^1.22.22"
-    },
-    "browserslist": {
-        "production": [
-            ">0.5%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    },
-    "packageManager": "yarn@3.2.3"
+  "name": "docs",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "docusaurus": "docusaurus",
+    "start": "docusaurus start",
+    "build": "docusaurus build",
+    "swizzle": "docusaurus swizzle",
+    "deploy": "docusaurus deploy",
+    "serve": "docusaurus serve",
+    "spellcheck": "cspell \"docs/**\" --show-suggestions",
+    "spellcheck-on-pr": "cspell --no-must-find-files --file-list stdin"
+  },
+  "dependencies": {
+    "@cmfcmf/docusaurus-search-local": "^1.1.0",
+    "@docusaurus/core": "^3.1.1",
+    "@docusaurus/preset-classic": "^3.1.1",
+    "@mdx-js/react": "^3.0.1",
+    "clsx": "^2.1.0",
+    "cspell": "^8.6.1",
+    "docusaurus-lunr-search": "^3.3.2",
+    "dotenv": "^16.4.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "yarn": "^1.22.22"
+  },
+  "browserslist": {
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "packageManager": "yarn@3.2.3"
 }


### PR DESCRIPTION
## Changes
1. Upgrade `actions/checkout@v2` to `actions/checkout@v4` and `actions/setup-node@v3` to `actions/setup-node@v4`
2. Added `yarn spellcheck-on-pr` command `"spellcheck-on-pr": "cspell --no-must-find-files --file-list stdin"` on `package.json`
3. Created a spellcheck workflow which:
    1. Runs only on PRs to `main` branch
    2. Uses `tj-actions/changed-files@v44` to get a list of the changed files **in the docs directory** on that PR
    3. Run `echo $ALL_CHANGED_FILES | yarn spellcheck-on-pr` **only** if there are changed files that match the above condition

## How to test?
Not sure, I think it needs to be merged so it can run afterwards on the existing PR.