### PR TITLE
[EMB-482] Refactor freq table and add 923 MHz version

### DIFF
--- a/docs/wxm-devices/frequency-explanation-d1-m5-pulse.mdx
+++ b/docs/wxm-devices/frequency-explanation-d1-m5-pulse.mdx
@@ -2,7 +2,7 @@ import React from 'react';
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css'; // optional
 
-<Tippy content="For D1, M5 and Pulse, both frequencies (EU868 , US915) work reliably everywhere in the world.
+<Tippy content="For D1, M5 and Pulse, all 3 available frequency models (EU868 , US915, US923) work reliably everywhere in the world.
   The appropriate ISM license frequency is subject to local authorities and
   we do not have a definitive answer for this particular location.">
   <button>?</button>

--- a/docs/wxm-devices/frequency-plans.mdx
+++ b/docs/wxm-devices/frequency-plans.mdx
@@ -21,23 +21,23 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 | Country            | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2        |
 |--------------------|--------------|---------------|----------------|---------------|
 | Afghanistan        | AF           | -             | <FreqExplanation/> | Not Supported |
-| Aland Islands      | AX           | EU868         | 868 MHz            | ✓             |
-| Albania            | AL           | EU868         | 868 MHz            | ✓             |
-| Algeria            | DZ           | AS923_3       | 915 MHz            | ✓             |
-| American Samoa     | AS           | US915         | 915 MHz            | ✓             |
-| Andorra            | AD           | EU868         | 868 MHz            | ✓             |
+| Aland Islands      | AX           | EU868         | EU868              | ✓             |
+| Albania            | AL           | EU868         | EU868              | ✓             |
+| Algeria            | DZ           | AS923_3       | US915              | ✓             |
+| American Samoa     | AS           | US915         | US915              | ✓             |
+| Andorra            | AD           | EU868         | EU868              | ✓             |
 | Angola             | AO           | -             | <FreqExplanation/> | Not Supported |
-| Anguilla           | AI           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Anguilla           | AI           | AU915_SB1     | US915 and AS923    | ✓             |
 | Antarctica - Chilean | AQ         | -             | <FreqExplanation/> | Not Supported |
 | Antarctica - Australian | AQ      | -             | <FreqExplanation/> | Not Supported |
 | Antarctica - British | AQ         | -             | <FreqExplanation/> | Not Supported |
 | Antarctica - Argentine | AQ       | -             | <FreqExplanation/> | Not Supported |
 | Antigua and Barbuda | AG          | -             | <FreqExplanation/> | Not Supported |
-| Argentina          | AR           | AU915_SB1     | 915 and 923 MHz    | ✓             |
-| Armenia            | AM           | EU868         | 868 MHz            | ✓             |
+| Argentina          | AR           | AU915_SB1     | US915 and AS923    | ✓             |
+| Armenia            | AM           | EU868         | EU868              | ✓             |
 | Aruba              | AW           | -             | <FreqExplanation/> | Not Supported |
-| Australia          | AU           | AU915_SB2     | 915 and 923 MHz    | ✓             |
-| Austria            | AT           | EU868         | 868 MHz            | ✓             |
+| Australia          | AU           | AU915_SB2     | US915 and AS923    | ✓             |
+| Austria            | AT           | EU868         | EU868              | ✓             |
 | Azerbaijan         | AZ           | EU433         | <FreqExplanation/> | Not supported |
 
 
@@ -45,76 +45,76 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 
 | Country                        | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |--------------------------------|--------------|---------------|--------------------|---------------|
-| Bahamas                        | BS           | US915         | 915 MHz            | ✓             |
-| Bahrain                        | BH           | EU868         | 868 MHz            | ✓             |
-| Bangladesh                     | BD           | AS923_1       | 923 MHz            | ✓             |
-| Barbados                       | BB           | AU915_SB1     | 915 and 923 MHz    | ✓             |
-| Belarus                        | BY           | EU868         | 868 MHz            | ✓             |
-| Belgium                        | BE           | EU868         | 868 MHz            | ✓             |
-| Belize                         | BZ           | AU915_SB1     | 915 and 923 MHz    | ✓             |
-| Benin                          | BJ           | EU868         | 868 MHz            | ✓             |
-| Bermuda                        | BM           | US915         | 915 MHz            | ✓             |
-| Bhutan                         | BT           | EU868         | 868 MHz            | ✓             |
-| Bolivia                        | BO           | AS923_1       | 915 and 923 MHz    | ✓             |
-| Bonaire, Sint Eustatius & Saba | BQ           | EU868         | 868 MHz            | ✓             |
-| Bosnia and Herzegovina         | BA           | EU868         | 868 MHz            | ✓             |
-| Botswana                       | BW           | EU868         | 868 MHz            | ✓             |
-| Bouvet Island                  | BV           | EU868         | 868 MHz            | ✓             |
-| Brazil                         | BR           | AU915_SB2     | 915 and 923 MHz    | ✓             |
+| Bahamas                        | BS           | US915         | US915              | ✓             |
+| Bahrain                        | BH           | EU868         | EU868              | ✓             |
+| Bangladesh                     | BD           | AS923_1       | AS923              | ✓             |
+| Barbados                       | BB           | AU915_SB1     | US915 and AS923    | ✓             |
+| Belarus                        | BY           | EU868         | EU868              | ✓             |
+| Belgium                        | BE           | EU868         | EU868              | ✓             |
+| Belize                         | BZ           | AU915_SB1     | US915 and AS923    | ✓             |
+| Benin                          | BJ           | EU868         | EU868              | ✓             |
+| Bermuda                        | BM           | US915         | US915              | ✓             |
+| Bhutan                         | BT           | EU868         | EU868              | ✓             |
+| Bolivia                        | BO           | AS923_1       | US915 and AS923    | ✓             |
+| Bonaire, Sint Eustatius & Saba | BQ           | EU868         | EU868              | ✓             |
+| Bosnia and Herzegovina         | BA           | EU868         | EU868              | ✓             |
+| Botswana                       | BW           | EU868         | EU868              | ✓             |
+| Bouvet Island                  | BV           | EU868         | EU868              | ✓             |
+| Brazil                         | BR           | AU915_SB2     | US915 and AS923    | ✓             |
 | British Indian Ocean Territory | IO           | -             | <FreqExplanation/> | Not Supported |
-| British Virgin Islands         | VG           | AU915_SB1     | 915 and 923 MHz    | ✓             |
-| Brunei                         | BN           | AS923_1       | 923 MHz            | ✓             |
-| Bulgaria                       | BG           | EU868         | 868 MHz            | ✓             |
+| British Virgin Islands         | VG           | AU915_SB1     | US915 and AS923    | ✓             |
+| Brunei                         | BN           | AS923_1       | AS923              | ✓             |
+| Bulgaria                       | BG           | EU868         | EU868              | ✓             |
 | Burkina Faso                   | BF           | -             | <FreqExplanation/> | Not Supported |
-| Burundi                        | BI           | EU868         | 868 MHz            | ✓             |
+| Burundi                        | BI           | EU868         | EU868              | ✓             |
 
 ## C
 
 | Country                   | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |---------------------------|--------------|---------------|--------------------|----------------|
-| Cambodia                  | KH           | AS923_1       | 923 MHz            | ✓              |
+| Cambodia                  | KH           | AS923_1       | AS923              | ✓              |
 | Cameroon                  | CM           | EU433         | <FreqExplanation/> | Not Supported  |
-| Canada                    | CA           | US915         | 915 MHz            | ✓              |
-| Cape Verde                | CV           | EU868         | 868 MHz            | ✓              |
-| Cayman Islands            | KY           | US915         | 915 MHz            | ✓              |
+| Canada                    | CA           | US915         | US915              | ✓              |
+| Cape Verde                | CV           | EU868         | EU868              | ✓              |
+| Cayman Islands            | KY           | US915         | US915              | ✓              |
 | Central African Republic  | CF           | -             | <FreqExplanation/> | Not Supported  |
 | Chad                      | TD           | -             | <FreqExplanation/> | Not Supported  |
-| Chile                     | CL           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Chile                     | CL           | AU915_SB1     | US915 and AS923    | ✓              |
 | China                     | CN           | CN470         | <FreqExplanation/> | ✓              |
-| Christmas Island          | CX           | AU915_SB2     | 915 and 923 MHz    | ✓              |
-| Cocos (Keeling) Islands   | CC           | AU915_SB2     | 915 and 923 MHz    | ✓              |
-| Colombia                  | CO           | AU915_SB1     | 915 and 923 MHz    | ✓              |
-| Comoros                   | KM           | EU868         | 868 MHz            | ✓              |
+| Christmas Island          | CX           | AU915_SB2     | US915 and AS923    | ✓              |
+| Cocos (Keeling) Islands   | CC           | AU915_SB2     | US915 and AS923    | ✓              |
+| Colombia                  | CO           | AU915_SB1     | US915 and AS923    | ✓              |
+| Comoros                   | KM           | EU868         | EU868              | ✓              |
 | Congo (DRC)               | CD           | -             | <FreqExplanation/> | Not Supported  |
 | Congo (Republic)          | CG           | -             | <FreqExplanation/> | Not Supported  |
-| Cook Islands              | CK           | AS923_1       | 915 and 923 MHz    | ✓              |
-| Costa Rica                | CR           | AS923_1       | 923 MHz            | ✓              |
-| Côte d'Ivoire             | CI           | EU868         | 868 MHz            | ✓              |
-| Croatia                   | HR           | EU868         | 868 MHz            | ✓              |
-| Cuba                      | CU           | AS923_3       | 915 MHz            | ✓              |
-| Curaçao                   | CW           | AS923_1       | 923 MHz            | ✓              |
-| Cyprus                    | CY           | EU868         | 868 MHz            | ✓              |
-| Czech Republic            | CZ           | EU868         | 868 MHz            | ✓              |
+| Cook Islands              | CK           | AS923_1       | US915 and AS923    | ✓              |
+| Costa Rica                | CR           | AS923_1       | AS923              | ✓              |
+| Côte d'Ivoire             | CI           | EU868         | EU868              | ✓              |
+| Croatia                   | HR           | EU868         | EU868              | ✓              |
+| Cuba                      | CU           | AS923_3       | US915              | ✓              |
+| Curaçao                   | CW           | AS923_1       | AS923              | ✓              |
+| Cyprus                    | CY           | EU868         | EU868              | ✓              |
+| Czech Republic            | CZ           | EU868         | EU868              | ✓              |
 
 ## D
 
 | Country            | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |--------------------|--------------|---------------|--------------------|---------------|
-| Denmark            | DK           | EU868         | 868 MHz            | ✓             |
+| Denmark            | DK           | EU868         | EU868              | ✓             |
 | Djibouti           | DJ           | -             | <FreqExplanation/> | Not Supported |
-| Dominica           | DM           | AU915_SB1     | 915 and 923 MHz    | ✓             |
-| Dominican Republic | DO           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Dominica           | DM           | AU915_SB1     | US915 and AS923    | ✓             |
+| Dominican Republic | DO           | AU915_SB1     | US915 and AS923    | ✓             |
 
 ## E
 
 | Country                | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |------------------------|--------------|---------------|--------------------|----------------|
-| Ecuador                | EC           | AU915_SB1     | 915 and 923 MHz    | ✓              |
-| Egypt                  | EG           | EU868         | 868 MHz            | ✓              |
-| El Salvador            | SV           | AU915_SB1     | 915 and 923 MHz    | ✓              |
-| Equatorial Guinea      | GQ           | EU868         | 868 MHz            | ✓              |
+| Ecuador                | EC           | AU915_SB1     | US915 and AS923    | ✓              |
+| Egypt                  | EG           | EU868         | EU868              | ✓              |
+| El Salvador            | SV           | AU915_SB1     | US915 and AS923    | ✓              |
+| Equatorial Guinea      | GQ           | EU868         | EU868              | ✓              |
 | Eritrea                | ER           | -             | <FreqExplanation/> | Not Supported  |
-| Estonia                | EE           | EU868         | 868 MHz            | ✓              |
+| Estonia                | EE           | EU868         | EU868              | ✓              |
 | Eswatini (Swaziland)   | SZ           | -             | <FreqExplanation/> | Not Supported  |
 | Ethiopia               | ET           | -             | <FreqExplanation/> | Not Supported  |
 
@@ -122,14 +122,14 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 
 | Country                    | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |----------------------------|--------------|---------------|--------------------|----------------|
-| Falkland Islands            | FK           | EU868         | 868 MHz            | ✓              |
-| Faroe Islands               | FO           | EU868         | 868 MHz            | ✓              |
+| Falkland Islands            | FK           | EU868         | EU868              | ✓              |
+| Faroe Islands               | FO           | EU868         | EU868              | ✓              |
 | Fiji                        | FJ           | -             | <FreqExplanation/> | Not Supported  |
-| Finland                     | FI           | EU868         | 868 MHz            | ✓              |
-| France                      | FR           | EU868         | 868 MHz            | ✓              |
-| French Guiana               | GF           | EU868         | 868 MHz            | ✓              |
-| French Polynesia            | PF           | EU868         | 868 MHz            | ✓              |
-| French Southern Territories | TF           | EU868         | 868 MHz            | ✓              |
+| Finland                     | FI           | EU868         | EU868              | ✓              |
+| France                      | FR           | EU868         | EU868              | ✓              |
+| French Guiana               | GF           | EU868         | EU868              | ✓              |
+| French Polynesia            | PF           | EU868         | EU868              | ✓              |
+| French Southern Territories | TF           | EU868         | EU868              | ✓              |
 
 ## G
 
@@ -138,52 +138,52 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 | Gabon             | GA           | -             | <FreqExplanation/> | Not Supported  |
 | Gambia            | GM           | EU433         | <FreqExplanation/> | Not Supported  |
 | Gaza Strip        | PS           | -             | <FreqExplanation/> | Not Supported  |
-| Georgia           | GE           | EU868         | 868 MHz            | ✓              |
-| Germany           | DE           | EU868         | 868 MHz            | ✓              |
+| Georgia           | GE           | EU868         | EU868              | ✓              |
+| Germany           | DE           | EU868         | EU868              | ✓              |
 | Ghana             | GH           | EU433         | <FreqExplanation/> | Not Supported  |
-| Gibraltar         | GI           | EU868         | 868 MHz            | ✓              |
-| Greece            | GR           | EU868         | 868 MHz            | ✓              |
-| Greenland         | GL           | EU868         | 868 MHz            | ✓              |
-| Grenada           | GD           | AU915_SB1     | 915 and 923 MHz    | ✓              |
-| Guadeloupe        | GP           | EU868         | 868 MHz            | ✓              |
-| Guam              | GU           | US915         | 915 MHz            | ✓              |
-| Guatemala         | GT           | AU915_SB1     | 915 and 923 MHz    | ✓              |
-| Guernsey          | GG           | EU868         | 868 MHz            | ✓              |
+| Gibraltar         | GI           | EU868         | EU868              | ✓              |
+| Greece            | GR           | EU868         | EU868              | ✓              |
+| Greenland         | GL           | EU868         | EU868              | ✓              |
+| Grenada           | GD           | AU915_SB1     | US915 and AS923    | ✓              |
+| Guadeloupe        | GP           | EU868         | EU868              | ✓              |
+| Guam              | GU           | US915         | US915              | ✓              |
+| Guatemala         | GT           | AU915_SB1     | US915 and AS923    | ✓              |
+| Guernsey          | GG           | EU868         | EU868              | ✓              |
 | Guinea            | GN           | EU433         | <FreqExplanation/> | Not Supported  |
 | Guinea-Bissau     | GW           | -             | <FreqExplanation/> | Not Supported  |
-| Guyana            | GY           | US915         | 915 MHz            | ✓              |
+| Guyana            | GY           | US915         | US915              | ✓              |
 
 ## H
 
 | Country                           | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |-----------------------------------|--------------|---------------|--------------------|----------------|
 | Haiti                             | HT           | -             | <FreqExplanation/> | Not Supported  |
-| Heard Island and McDonald Islands | HM           | AU915_SB2     | 915 and 923 MHz    | ✓              |
-| Honduras                          | HN           | AU915_SB1     | 915 and 923 MHz    | ✓              |
-| Hong Kong                         | HK           | AS923_1       | 923 MHz            | ✓              |
-| Hungary                           | HU           | EU868         | 868 MHz            | ✓              |
+| Heard Island and McDonald Islands | HM           | AU915_SB2     | US915 and AS923    | ✓              |
+| Honduras                          | HN           | AU915_SB1     | US915 and AS923    | ✓              |
+| Hong Kong                         | HK           | AS923_1       | AS923               | ✓              |
+| Hungary                           | HU           | EU868         | EU868              | ✓              |
 
 ## I
 
 | Country          | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2 |
 |------------------|--------------|---------------|--------------------|-------|
-| Iceland          | IS           | EU868         | 868 MHz            | ✓     |
+| Iceland          | IS           | EU868         | EU868              | ✓     |
 | India            | IN           | IN865         | <FreqExplanation/> | ✓     |
-| Indonesia        | ID           | AS923_2       | 923 MHz            | ✓     |
-| Iran             | IR           | EU868         | 868 MHz            | ✓     |
-| Iraq             | IQ           | EU868         | 868 MHz            | ✓     |
-| Ireland          | IE           | EU868         | 868 MHz            | ✓     |
-| Isle of Man      | IM           | EU868         | 868 MHz            | ✓     |
+| Indonesia        | ID           | AS923_2       | AS923              | ✓     |
+| Iran             | IR           | EU868         | EU868              | ✓     |
+| Iraq             | IQ           | EU868         | EU868              | ✓     |
+| Ireland          | IE           | EU868         | EU868              | ✓     |
+| Isle of Man      | IM           | EU868         | EU868              | ✓     |
 | Israel           | IL           | AS923_4       | <FreqExplanation/> | ✓     |
-| Italy            | IT           | EU868         | 868 MHz            | ✓     |
+| Italy            | IT           | EU868         | EU868              | ✓     |
 
 ## J
 
 | Country  | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2  |
 |----------|--------------|---------------|--------------------|--------|
-| Jamaica  | JM           | AU915_SB1     | 915 and 923 MHz    | ✓      |
-| Japan    | JP           | AS923_1       | 923 MHz            | ✓      |
-| Jersey   | JE           | EU868         | 868 MHz            | ✓      |
+| Jamaica  | JM           | AU915_SB1     | US915 and AS923    | ✓      |
+| Japan    | JP           | AS923_1       | AS923              | ✓      |
+| Jersey   | JE           | EU868         | EU868              | ✓      |
 | Jordan   | JO           | IN865         | ✓                  | ✓      |
 
 ## K
@@ -191,79 +191,79 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 | Country    | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |------------|--------------|---------------|--------------------|----------------|
 | Kazakhstan | KZ           | IN865         | <FreqExplanation/> | ✓              |
-| Kenya      | KE           | EU868         | 868 MHz            | ✓              |
+| Kenya      | KE           | EU868         | EU868              | ✓              |
 | Kiribati   | KI           | -             | <FreqExplanation/> | Not Supported  |
-| Kosovo     | XK           | EU868         | 868 MHz            | ✓              |
-| Kuwait     | KW           | EU868         | 868 MHz            | ✓              |
+| Kosovo     | XK           | EU868         | EU868              | ✓              |
+| Kuwait     | KW           | EU868         | EU868              | ✓              |
 | Kyrgyzstan | KG           | -             | <FreqExplanation/> | Not Supported  |
 
 ## L
 
 | Country          | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |------------------|--------------|---------------|--------------------|----------------|
-| Laos             | LA           | AS923_1       | 923 MHz            | ✓              |
-| Latvia           | LV           | EU868         | 868 MHz            | ✓              |
-| Lebanon          | LB           | EU868         | 868 MHz            | ✓              |
+| Laos             | LA           | AS923_1       | AS923              | ✓              |
+| Latvia           | LV           | EU868         | EU868              | ✓              |
+| Lebanon          | LB           | EU868         | EU868              | ✓              |
 | Lesotho          | LS           | EU433         | <FreqExplanation/> | Not Supported  |
 | Liberia          | LR           | -             | <FreqExplanation/> | Not Supported  |
 | Libya            | LY           | -             | <FreqExplanation/> | Not Supported  |
-| Liechtenstein    | LI           | EU868         | 868 MHz            | ✓              |
-| Lithuania        | LT           | EU868         | 868 MHz            | ✓              |
-| Luxembourg       | LU           | EU868         | 868 MHz            | ✓              |
+| Liechtenstein    | LI           | EU868         | EU868              | ✓              |
+| Lithuania        | LT           | EU868         | EU868              | ✓              |
+| Luxembourg       | LU           | EU868         | EU868              | ✓              |
 
 ## M
 
 | Country            | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |--------------------|--------------|---------------|--------------------|----------------|
-| Macau              | MO           | AS923_1       | 923 MHz            | ✓              |
-| North Macedonia    | MK           | EU868         | 868 MHz            | ✓              |
-| Madagascar         | MG           | EU868         | 868 MHz            | ✓              |
+| Macau              | MO           | AS923_1       | AS923              | ✓              |
+| North Macedonia    | MK           | EU868         | EU868              | ✓              |
+| Madagascar         | MG           | EU868         | EU868              | ✓              |
 | Malawi             | MW           | -             | <FreqExplanation/> | Not Supported  |
-| Malaysia           | MY           | AS923_1B      | 923 MHz            | ✓              |
+| Malaysia           | MY           | AS923_1B      | AS923              | ✓              |
 | Maldives           | MV           | -             | <FreqExplanation/> | Not Supported  |
 | Mali               | ML           | EU433         | <FreqExplanation/> | Not Supported  |
-| Malta              | MT           | EU868         | 868 MHz            | ✓              |
+| Malta              | MT           | EU868         | EU868              | ✓              |
 | Marshall Islands   | MH           | -             | <FreqExplanation/> | Not Supported  |
-| Martinique         | MQ           | EU868         | 868 MHz            | ✓              |
-| Mauritania         | MR           | EU868         | 868 MHz            | ✓              |
+| Martinique         | MQ           | EU868         | EU868              | ✓              |
+| Mauritania         | MR           | EU868         | EU868              | ✓              |
 | Mauritius          | MU           | EU433         | <FreqExplanation/> | Not Supported  |
-| Mayotte            | YT           | EU868         | 868 MHz            | ✓              |
-| Mexico             | MX           | US915         | 915 MHz            | ✓              |
+| Mayotte            | YT           | EU868         | EU868              | ✓              |
+| Mexico             | MX           | US915         | US915              | ✓              |
 | Micronesia         | FM           | -             | <FreqExplanation/> | Not Supported  |
-| Moldova            | MD           | EU868         | 868 MHz            | ✓              |
-| Monaco             | MC           | EU868         | 868 MHz            | ✓              |
+| Moldova            | MD           | EU868         | EU868              | ✓              |
+| Monaco             | MC           | EU868         | EU868              | ✓              |
 | Mongolia           | MN           | -             | <FreqExplanation/> | Not Supported  |
-| Montenegro         | ME           | EU868         | 868 MHz            | ✓              |
-| Montserrat         | MS           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Montenegro         | ME           | EU868         | EU868              | ✓              |
+| Montserrat         | MS           | AU915_SB1     | US915 and AS923    | ✓              |
 | Morocco            | MA           | EU433         | <FreqExplanation/> | Not Supported  |
 | Mozambique         | MZ           | -             | <FreqExplanation/> | Not Supported  |
-| Myanmar            | MM           | AS923_1       | 923 MHz            | ✓              |
+| Myanmar            | MM           | AS923_1       | AS923              | ✓              |
 
 ## N
 
 | Country                  | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |--------------------------|--------------|---------------|----------------------|----------------|
-| Namibia                  | NA           | EU868         | 868 MHz                    | ✓              |
+| Namibia                  | NA           | EU868         | EU868                    | ✓              |
 | Nauru                    | NR           | -             | <FreqExplanation/>   | Not Supported  |
 | Nepal                    | NP           | -             | <FreqExplanation/>   | Not Supported  |
-| Netherlands              | NL           | EU868         | 868 MHz              | ✓              |
-| Netherlands Antilles     | AN           | EU868         | 868 MHz              | ✓              |
-| New Caledonia            | NC           | EU868         | 868 MHz              | ✓              |
-| New Zealand              | NZ           | AS923_1C      | 915 and 923 MHz      | ✓              |
-| Nicaragua                | NI           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Netherlands              | NL           | EU868         | EU868              | ✓              |
+| Netherlands Antilles     | AN           | EU868         | EU868              | ✓              |
+| New Caledonia            | NC           | EU868         | EU868              | ✓              |
+| New Zealand              | NZ           | AS923_1C      | US915 and AS923      | ✓              |
+| Nicaragua                | NI           | AU915_SB1     | US915 and AS923      | ✓              |
 | Niger                    | NE           | IN865         | <FreqExplanation/>   | ✓              |
-| Nigeria                  | NG           | EU868         | 868 MHz              | ✓              |
-| Niue                     | NU           | AS923_1       | 915 and 923 MHz      | ✓              |
-| Norfolk Island           | NF           | AU915_SB2     | 915 and 923 MHz      | ✓              |
+| Nigeria                  | NG           | EU868         | EU868              | ✓              |
+| Niue                     | NU           | AS923_1       | US915 and AS923      | ✓              |
+| Norfolk Island           | NF           | AU915_SB2     | US915 and AS923      | ✓              |
 | North Korea              | KP           | -             | <FreqExplanation/>   | Not Supported  |
-| Northern Mariana Islands | MP           | US915         | 915 MHz              | ✓              |
-| Norway                   | NO           | EU868         | 868 MHz              | ✓              |
+| Northern Mariana Islands | MP           | US915         | US915              | ✓              |
+| Norway                   | NO           | EU868         | EU868              | ✓              |
 
 ## O
 
 | Country  | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2 |
 |----------|--------------|---------------|-------------|-------|
-| Oman     | OM           | EU868         | 868 MHz     | ✓     |
+| Oman     | OM           | EU868         | EU868     | ✓     |
 
 ## P
 
@@ -272,117 +272,117 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 | Pakistan                | PK           | AS923         |✓                     | ✓              |
 | Palau                   | PW           | -             | <FreqExplanation/>   | Not Supported  |
 | Palestinian Territories | PS           | -             | <FreqExplanation/>   | Not Supported  |
-| Panama                  | PA           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Papua New Guinea        | PG           | AS923_1       | 915 and 923 MHz      | ✓              |
-| Paraguay                | PY           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Peru                    | PE           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Philippines             | PH           | AS923_3       | 915 MHz              | ✓              |
+| Panama                  | PA           | AU915_SB1     | US915 and AS923      | ✓              |
+| Papua New Guinea        | PG           | AS923_1       | US915 and AS923      | ✓              |
+| Paraguay                | PY           | AU915_SB1     | US915 and AS923      | ✓              |
+| Peru                    | PE           | AU915_SB1     | US915 and AS923      | ✓              |
+| Philippines             | PH           | AS923_3       | US915                | ✓              |
 | Pitcairn Islands        | PN           | -             | <FreqExplanation/>   | Not Supported  |
-| Poland                  | PL           | EU868         | 868 MHz              | ✓              |
-| Portugal                | PT           | EU868         | 868 MHz              | ✓              |
-| Puerto Rico             | PR           | US915         | 915 MHz              | ✓              |
+| Poland                  | PL           | EU868         | EU868                | ✓              |
+| Portugal                | PT           | EU868         | EU868                | ✓              |
+| Puerto Rico             | PR           | US915         | US915                | ✓              |
 
 ## Q
 
 | Country | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2 |
 |---------|--------------|---------------|-------------|-------|
-| Qatar   | QA           | EU868         | 868 MHz     | ✓     |
+| Qatar   | QA           | EU868         | EU868     | ✓     |
 
 ## R
 
 | Country            | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2 |
 |--------------------|--------------|---------------|--------------------|-------|
-| Réunion            | RE           | EU868         | 868 MHz            | ✓     |
-| Romania            | RO           | EU868         | 868 MHz            | ✓     |
+| Réunion            | RE           | EU868         | EU868              | ✓     |
+| Romania            | RO           | EU868         | EU868              | ✓     |
 | Russia             | RU           | RU864         | <FreqExplanation/> | ✓     |
-| Rwanda             | RW           | EU868         | 868 MHz            | ✓     |
+| Rwanda             | RW           | EU868         | EU868              | ✓     |
 
 ## S
 
 | Country                                  | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |------------------------------------------|--------------|---------------|----------------------|----------------|
 | Sahrawi Arab Democratic Republic         | EH           | -             | <FreqExplanation/>   | Not Supported  |
-| Saint Barthelemy                         | BL           | EU868         | 868 MHz                    | ✓              |
+| Saint Barthelemy                         | BL           | EU868         | EU868                    | ✓              |
 | Saint Helena                             | SH           | -             | <FreqExplanation/>   | Not Supported  |
-| Saint Kitts and Nevis                    | KN           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Saint Lucia                              | LC           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Saint Martin                             | MF           | EU868         | 868 MHz              | ✓              |
-| Saint Pierre and Miquelon                | PM           | EU868         | 868 MHz              | ✓              |
-| Saint Vincent and the Grenadines         | VC           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Samoa                                    |              | EU868         | 868 MHz              | ✓              |
-| San Marino                               | SM           | EU868         | 868 MHz              | ✓              |
+| Saint Kitts and Nevis                    | KN           | AU915_SB1     | US915 and AS923      | ✓              |
+| Saint Lucia                              | LC           | AU915_SB1     | US915 and AS923      | ✓              |
+| Saint Martin                             | MF           | EU868         | EU868                | ✓              |
+| Saint Pierre and Miquelon                | PM           | EU868         | EU868                | ✓              |
+| Saint Vincent and the Grenadines         | VC           | AU915_SB1     | US915 and AS923      | ✓              |
+| Samoa                                    |              | EU868         | EU868                | ✓              |
+| San Marino                               | SM           | EU868         | EU868                | ✓              |
 | São Tomé and Príncipe                    | ST           | -             | <FreqExplanation/>   | Not Supported  |
-| Saudi Arabia                             | SA           | EU868         | 868 MHz              | ✓              |
-| Senegal                                  | SN           | EU868         | 868 MHz              | ✓              |
-| Serbia                                   | RS           | EU868         | 868 MHz              | ✓              |
+| Saudi Arabia                             | SA           | EU868         | EU868                | ✓              |
+| Senegal                                  | SN           | EU868         | EU868                | ✓              |
+| Serbia                                   | RS           | EU868         | EU868                | ✓              |
 | Seychelles                               | SC           | EU433         | <FreqExplanation/>   | Not supported  |
-| Sierra Leone                             | SL           | EU868         | 868 MHz              | ✓              |
-| Singapore                                | SG           | AS923_1       | 923 MHz              | ✓              |
-| Slovakia                                 | SK           | EU868         | 868 MHz              | ✓              |
-| Slovenia                                 | SI           | EU868         | 868 MHz              | ✓              |
-| Solomon Islands                          | SB           | AS923_1       | 923 MHz              | ✓              |
-| Somalia                                  | SO           | EU868         | 868 MHz              | ✓              |
-| South Africa                             | ZA           | EU868         | 868 MHz              | ✓              |
-| South Georgia and the South Sandwich Islands | GS       | EU868         | 868 MHz              | ✓              |
+| Sierra Leone                             | SL           | EU868         | EU868                | ✓              |
+| Singapore                                | SG           | AS923_1       | AS923                | ✓              |
+| Slovakia                                 | SK           | EU868         | EU868                | ✓              |
+| Slovenia                                 | SI           | EU868         | EU868                | ✓              |
+| Solomon Islands                          | SB           | AS923_1       | AS923                | ✓              |
+| Somalia                                  | SO           | EU868         | EU868                | ✓              |
+| South Africa                             | ZA           | EU868         | EU868                | ✓              |
+| South Georgia and the South Sandwich Islands | GS       | EU868         | EU868                | ✓              |
 | South Korea                              | KR           | KR920         | <FreqExplanation/>   | ✓              |
 | South Sudan                              | SS           | -             | <FreqExplanation/>   | Not Supported  |
-| Spain                                    | ES           | EU868         | 868 MHz              | ✓              |
-| Sri Lanka                                | LK           | AS923_1       | 923 MHz              | ✓              |
+| Spain                                    | ES           | EU868         | EU868                | ✓              |
+| Sri Lanka                                | LK           | AS923_1       | AS923                | ✓              |
 | Sudan                                    | SD           | -             | <FreqExplanation/>   | Not Supported  |
-| Suriname                                 | SR           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Svalbard and Jan Mayen                   | SJ           | EU868         | 868 MHz              | ✓              |
-| Sweden                                   | SE           | EU868         | 868 MHz              | ✓              |
-| Switzerland                              | CH           | EU868         | 868 MHz              | ✓              |
-| Syria                                    | SY           | EU868         | 868 MHz              | ✓              |
+| Suriname                                 | SR           | AU915_SB1     | US915 and AS923      | ✓              |
+| Svalbard and Jan Mayen                   | SJ           | EU868         | EU868                | ✓              |
+| Sweden                                   | SE           | EU868         | EU868                | ✓              |
+| Switzerland                              | CH           | EU868         | EU868                | ✓              |
+| Syria                                    | SY           | EU868         | EU868                | ✓              |
 
 ## T
 
 | Country                  | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |--------------------------|--------------|---------------|----------------------|----------------|
-| Taiwan                   | TW           | AS923_1       | 923 MHz              | ✓              |
+| Taiwan                   | TW           | AS923_1       | AS923                | ✓              |
 | Tajikistan               | TJ           | -             | <FreqExplanation/>   | Not Supported  |
-| Tanzania                 | TZ           | AS923_1       | 923 MHz              | ✓              |
-| Thailand                 | TH           | AS923_1       | 923 MHz              | ✓              |
+| Tanzania                 | TZ           | AS923_1       | AS923                | ✓              |
+| Thailand                 | TH           | AS923_1       | AS923                | ✓              |
 | Timor-Leste              | TL           | -             | <FreqExplanation/>   | Not Supported  |
 | Togo                     | TG           | EU433         | <FreqExplanation/>   | Not supported  |
-| Tokelau                  | TK           | AS923_1       | 923 MHz              | ✓              |
-| Tonga                    | TO           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Trinidad and Tobago      | TT           | AU915_SB1     | 915 and 923 MHz      | ✓              |
-| Tunisia                  | TN           | EU868         | 868 MHz              | ✓              |
-| Turkey                   | TR           | EU868         | 868 MHz              | ✓              |
+| Tokelau                  | TK           | AS923_1       | AS923                | ✓              |
+| Tonga                    | TO           | AU915_SB1     | US915 and AS923      | ✓              |
+| Trinidad and Tobago      | TT           | AU915_SB1     | US915 and AS923      | ✓              |
+| Tunisia                  | TN           | EU868         | EU868                | ✓              |
+| Turkey                   | TR           | EU868         | EU868                | ✓              |
 | Turkmenistan             | TM           | -             | <FreqExplanation/>   | Not Supported  |
-| Turks and Caicos Islands | TC           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Turks and Caicos Islands | TC           | AU915_SB1     | US915 and AS923      | ✓              |
 | Tuvalu                   | TV           | -             | <FreqExplanation/>   | Not Supported  |
 
 ## U
 
 | Country                     | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |-----------------------------|--------------|---------------|--------------------|---------------|
-| U.S. Minor Outlying Islands | UM           | US915         | 915 MHz            | ✓             |
-| U.S. Virgin Islands         | VI           | US915         | 915 MHz            | ✓             |
-| Uganda                      | UG           | AS923_1       | 923 MHz            | ✓             |
-| Ukraine                     | UA           | EU868         | 868 MHz            | ✓             |
-| United Arab Emirates        | AE           | EU868         | 868 MHz            | ✓             |
-| United Kingdom              | GB           | EU868         | 868 MHz            | ✓             |
-| United States               | US           | US915         | 915 MHz            | ✓             |
-| Uruguay                     | UY           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| U.S. Minor Outlying Islands | UM           | US915         | US915              | ✓             |
+| U.S. Virgin Islands         | VI           | US915         | US915              | ✓             |
+| Uganda                      | UG           | AS923_1       | AS923              | ✓             |
+| Ukraine                     | UA           | EU868         | EU868              | ✓             |
+| United Arab Emirates        | AE           | EU868         | EU868              | ✓             |
+| United Kingdom              | GB           | EU868         | EU868              | ✓             |
+| United States               | US           | US915         | US915              | ✓             |
+| Uruguay                     | UY           | AU915_SB1     | US915 and AS923    | ✓             |
 | Uzbekistan                  | UZ           | EU433         | <FreqExplanation/> | Not supported |
 
 ## V
 
 | Country             | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2 |
 |---------------------|--------------|---------------|--------------------|-------|
-| Vanuatu             | VU           | AS923_3       | 915 MHz            | ✓     |
-| Vatican City        | VA           | EU868         | 868 MHz            | ✓     |
-| Venezuela           | VE           | AS923_1       | 923 MHz            | ✓     |
-| Vietnam             | VN           | AS923_2       | 923 MHz            | ✓     |
-| Virgin Islands (UK) | VG           | AU915_SB1     | 915 and 923 MHz    | ✓     |
+| Vanuatu             | VU           | AS923_3       | US915              | ✓     |
+| Vatican City        | VA           | EU868         | EU868              | ✓     |
+| Venezuela           | VE           | AS923_1       | AS923              | ✓     |
+| Vietnam             | VN           | AS923_2       | AS923              | ✓     |
+| Virgin Islands (UK) | VG           | AU915_SB1     | US915 and AS923    | ✓     |
 
 ## W
 
 | Country           | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |-------------------|--------------|---------------|--------------------|---------------|
-| Wallis and Futuna | WF           | EU868         | 868 MHz            | ✓             |
+| Wallis and Futuna | WF           | EU868         | EU868              | ✓             |
 | Western Sahara    | EH           | -             | <FreqExplanation/> | Not Supported |
 
 ## Y
@@ -395,12 +395,12 @@ Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content
 
 | Country  | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2 |
 |----------|--------------|---------------|-------------|-------|
-| Zambia   | ZM           | EU868         | 868 MHz           | ✓     |
-| Zimbabwe | ZW           | EU868         | 868 MHz           | ✓     |
+| Zambia   | ZM           | EU868         | EU868       | ✓     |
+| Zimbabwe | ZW           | EU868         | EU868       | ✓     |
 
 
 :::info
-Updated as of October 9, 2024.
+Updated March 2025.
 :::
 
 :::note

--- a/docs/wxm-devices/frequency-plans.mdx
+++ b/docs/wxm-devices/frequency-plans.mdx
@@ -16,385 +16,385 @@ regulatory body for each country in the list [here](https://en.wikipedia.org/wik
 
 ## A
 
-| Country            | Country Code | ISM Frequency | D1/M5/Pulse    | H1/H2        |
+| Country            | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2        |
 |--------------------|--------------|---------------|----------------|---------------|
 | Afghanistan        | AF           | -             | <FreqExplanation/> | Not Supported |
-| Aland Islands      | AX           | EU868         | ✓                  | ✓             |
-| Albania            | AL           | EU868         | ✓                  | ✓             |
-| Algeria            | DZ           | AS923_3       | <FreqExplanation/> | ✓             |
-| American Samoa     | AS           | US915         | ✓                  | ✓             |
-| Andorra            | AD           | EU868         | ✓                  | ✓             |
+| Aland Islands      | AX           | EU868         | 868 MHz            | ✓             |
+| Albania            | AL           | EU868         | 868 MHz            | ✓             |
+| Algeria            | DZ           | AS923_3       | 915 MHz            | ✓             |
+| American Samoa     | AS           | US915         | 915 MHz            | ✓             |
+| Andorra            | AD           | EU868         | 868 MHz            | ✓             |
 | Angola             | AO           | -             | <FreqExplanation/> | Not Supported |
-| Anguilla           | AI           | AU915_SB1     | <FreqExplanation/> | ✓             |
+| Anguilla           | AI           | AU915_SB1     | 915 and 923 MHz    | ✓             |
 | Antarctica - Chilean | AQ         | -             | <FreqExplanation/> | Not Supported |
 | Antarctica - Australian | AQ      | -             | <FreqExplanation/> | Not Supported |
 | Antarctica - British | AQ         | -             | <FreqExplanation/> | Not Supported |
 | Antarctica - Argentine | AQ       | -             | <FreqExplanation/> | Not Supported |
 | Antigua and Barbuda | AG          | -             | <FreqExplanation/> | Not Supported |
-| Argentina          | AR           | AU915_SB1     | <FreqExplanation/> | ✓             |
-| Armenia            | AM           | EU868         | ✓                  | ✓             |
+| Argentina          | AR           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Armenia            | AM           | EU868         | 868 MHz            | ✓             |
 | Aruba              | AW           | -             | <FreqExplanation/> | Not Supported |
-| Australia          | AU           | AU915_SB2     | <FreqExplanation/> | ✓             |
-| Austria            | AT           | EU868         | ✓                  | ✓             |
+| Australia          | AU           | AU915_SB2     | 915 and 923 MHz    | ✓             |
+| Austria            | AT           | EU868         | 868 MHz            | ✓             |
 | Azerbaijan         | AZ           | EU433         | <FreqExplanation/> | Not supported |
 
 
 ## B
 
-| Country                        | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2         |
+| Country                        | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |--------------------------------|--------------|---------------|--------------------|---------------|
-| Bahamas                        | BS           | US915         | ✓                  | ✓             |
-| Bahrain                        | BH           | EU868         | ✓                  | ✓             |
-| Bangladesh                     | BD           | AS923_1       |  ✓                | ✓             |
-| Barbados                       | BB           | AU915_SB1     | <FreqExplanation/> | ✓             |
-| Belarus                        | BY           | EU868         | ✓                  | ✓             |
-| Belgium                        | BE           | EU868         | ✓                  | ✓             |
-| Belize                         | BZ           | AU915_SB1     | <FreqExplanation/> | ✓             |
-| Benin                          | BJ           | EU868         | ✓                  | ✓             |
-| Bermuda                        | BM           | US915         | ✓                  | ✓             |
-| Bhutan                         | BT           | EU868         | ✓                  | ✓             |
-| Bolivia                        | BO           | AS923_1       | <FreqExplanation/> | ✓             |
-| Bonaire, Sint Eustatius & Saba | BQ           | EU868         | ✓                  | ✓             |
-| Bosnia and Herzegovina         | BA           | EU868         | ✓                  | ✓             |
-| Botswana                       | BW           | EU868         | ✓                  | ✓             |
-| Bouvet Island                  | BV           | EU868         | ✓                  | ✓             |
-| Brazil                         | BR           | AU915_SB2     | <FreqExplanation/> | ✓             |
+| Bahamas                        | BS           | US915         | 915 MHz            | ✓             |
+| Bahrain                        | BH           | EU868         | 868 MHz            | ✓             |
+| Bangladesh                     | BD           | AS923_1       | 923 MHz            | ✓             |
+| Barbados                       | BB           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Belarus                        | BY           | EU868         | 868 MHz            | ✓             |
+| Belgium                        | BE           | EU868         | 868 MHz            | ✓             |
+| Belize                         | BZ           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Benin                          | BJ           | EU868         | 868 MHz            | ✓             |
+| Bermuda                        | BM           | US915         | 915 MHz            | ✓             |
+| Bhutan                         | BT           | EU868         | 868 MHz            | ✓             |
+| Bolivia                        | BO           | AS923_1       | 915 and 923 MHz    | ✓             |
+| Bonaire, Sint Eustatius & Saba | BQ           | EU868         | 868 MHz            | ✓             |
+| Bosnia and Herzegovina         | BA           | EU868         | 868 MHz            | ✓             |
+| Botswana                       | BW           | EU868         | 868 MHz            | ✓             |
+| Bouvet Island                  | BV           | EU868         | 868 MHz            | ✓             |
+| Brazil                         | BR           | AU915_SB2     | 915 and 923 MHz    | ✓             |
 | British Indian Ocean Territory | IO           | -             | <FreqExplanation/> | Not Supported |
-| British Virgin Islands         | VG           | AU915_SB1     | <FreqExplanation/> | ✓             |
-| Brunei                         | BN           | AS923_1       | ✓                  | ✓             |
-| Bulgaria                       | BG           | EU868         | ✓                  | ✓             |
+| British Virgin Islands         | VG           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Brunei                         | BN           | AS923_1       | 923 MHz            | ✓             |
+| Bulgaria                       | BG           | EU868         | 868 MHz            | ✓             |
 | Burkina Faso                   | BF           | -             | <FreqExplanation/> | Not Supported |
-| Burundi                        | BI           | EU868         | ✓                  | ✓             |
+| Burundi                        | BI           | EU868         | 868 MHz            | ✓             |
 
 ## C
 
-| Country                   | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country                   | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |---------------------------|--------------|---------------|--------------------|----------------|
-| Cambodia                  | KH           | AS923_1       |  ✓                 | ✓              |
+| Cambodia                  | KH           | AS923_1       | 923 MHz            | ✓              |
 | Cameroon                  | CM           | EU433         | <FreqExplanation/> | Not Supported  |
-| Canada                    | CA           | US915         | ✓                  | ✓              |
-| Cape Verde                | CV           | EU868         | ✓                  | ✓              |
-| Cayman Islands            | KY           | US915         | ✓                  | ✓              |
+| Canada                    | CA           | US915         | 915 MHz            | ✓              |
+| Cape Verde                | CV           | EU868         | 868 MHz            | ✓              |
+| Cayman Islands            | KY           | US915         | 915 MHz            | ✓              |
 | Central African Republic  | CF           | -             | <FreqExplanation/> | Not Supported  |
 | Chad                      | TD           | -             | <FreqExplanation/> | Not Supported  |
-| Chile                     | CL           | AU915_SB1     | <FreqExplanation/> | ✓              |
+| Chile                     | CL           | AU915_SB1     | 915 and 923 MHz    | ✓              |
 | China                     | CN           | CN470         | <FreqExplanation/> | ✓              |
-| Christmas Island          | CX           | AU915_SB2     | <FreqExplanation/> | ✓              |
-| Cocos (Keeling) Islands   | CC           | AU915_SB2     | <FreqExplanation/> | ✓              |
-| Colombia                  | CO           | AU915_SB1     | <FreqExplanation/> | ✓              |
-| Comoros                   | KM           | EU868         | ✓                  | ✓              |
+| Christmas Island          | CX           | AU915_SB2     | 915 and 923 MHz    | ✓              |
+| Cocos (Keeling) Islands   | CC           | AU915_SB2     | 915 and 923 MHz    | ✓              |
+| Colombia                  | CO           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Comoros                   | KM           | EU868         | 868 MHz            | ✓              |
 | Congo (DRC)               | CD           | -             | <FreqExplanation/> | Not Supported  |
 | Congo (Republic)          | CG           | -             | <FreqExplanation/> | Not Supported  |
-| Cook Islands              | CK           | AS923_1       | <FreqExplanation/> | ✓              |
-| Costa Rica                | CR           | AS923_1       | ✓                  | ✓              |
-| Côte d'Ivoire             | CI           | EU868         | ✓                  | ✓              |
-| Croatia                   | HR           | EU868         | ✓                  | ✓              |
-| Cuba                      | CU           | AS923_3       | <FreqExplanation/> | ✓              |
-| Curaçao                   | CW           | AS923_1       |  ✓                 | ✓              |
-| Cyprus                    | CY           | EU868         | ✓                  | ✓              |
-| Czech Republic            | CZ           | EU868         | ✓                  | ✓              |
+| Cook Islands              | CK           | AS923_1       | 915 and 923 MHz    | ✓              |
+| Costa Rica                | CR           | AS923_1       | 923 MHz            | ✓              |
+| Côte d'Ivoire             | CI           | EU868         | 868 MHz            | ✓              |
+| Croatia                   | HR           | EU868         | 868 MHz            | ✓              |
+| Cuba                      | CU           | AS923_3       | 915 MHz            | ✓              |
+| Curaçao                   | CW           | AS923_1       | 923 MHz            | ✓              |
+| Cyprus                    | CY           | EU868         | 868 MHz            | ✓              |
+| Czech Republic            | CZ           | EU868         | 868 MHz            | ✓              |
 
 ## D
 
-| Country            | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2         |
+| Country            | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |--------------------|--------------|---------------|--------------------|---------------|
-| Denmark            | DK           | EU868         | ✓                  | ✓             |
+| Denmark            | DK           | EU868         | 868 MHz            | ✓             |
 | Djibouti           | DJ           | -             | <FreqExplanation/> | Not Supported |
-| Dominica           | DM           | AU915_SB1     | ✓                  | ✓             |
-| Dominican Republic | DO           | AU915_SB1     | <FreqExplanation/> | ✓             |
+| Dominica           | DM           | AU915_SB1     | 915 and 923 MHz    | ✓             |
+| Dominican Republic | DO           | AU915_SB1     | 915 and 923 MHz    | ✓             |
 
 ## E
 
-| Country                | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country                | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |------------------------|--------------|---------------|--------------------|----------------|
-| Ecuador                | EC           | AU915_SB1     | <FreqExplanation/> | ✓              |
-| Egypt                  | EG           | EU868         | ✓                  | ✓              |
-| El Salvador            | SV           | AU915_SB1     | <FreqExplanation/> | ✓              |
-| Equatorial Guinea      | GQ           | EU868         | ✓                  | ✓              |
+| Ecuador                | EC           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Egypt                  | EG           | EU868         | 868 MHz            | ✓              |
+| El Salvador            | SV           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Equatorial Guinea      | GQ           | EU868         | 868 MHz            | ✓              |
 | Eritrea                | ER           | -             | <FreqExplanation/> | Not Supported  |
-| Estonia                | EE           | EU868         | ✓                  | ✓              |
+| Estonia                | EE           | EU868         | 868 MHz            | ✓              |
 | Eswatini (Swaziland)   | SZ           | -             | <FreqExplanation/> | Not Supported  |
 | Ethiopia               | ET           | -             | <FreqExplanation/> | Not Supported  |
 
 ## F
 
-| Country                    | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country                    | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |----------------------------|--------------|---------------|--------------------|----------------|
-| Falkland Islands            | FK           | EU868         | ✓                  | ✓              |
-| Faroe Islands               | FO           | EU868         | ✓                  | ✓              |
+| Falkland Islands            | FK           | EU868         | 868 MHz            | ✓              |
+| Faroe Islands               | FO           | EU868         | 868 MHz            | ✓              |
 | Fiji                        | FJ           | -             | <FreqExplanation/> | Not Supported  |
-| Finland                     | FI           | EU868         | ✓                  | ✓              |
-| France                      | FR           | EU868         | ✓                  | ✓              |
-| French Guiana               | GF           | EU868         | ✓                  | ✓              |
-| French Polynesia            | PF           | EU868         | ✓                  | ✓              |
-| French Southern Territories | TF           | EU868         | ✓                  | ✓              |
+| Finland                     | FI           | EU868         | 868 MHz            | ✓              |
+| France                      | FR           | EU868         | 868 MHz            | ✓              |
+| French Guiana               | GF           | EU868         | 868 MHz            | ✓              |
+| French Polynesia            | PF           | EU868         | 868 MHz            | ✓              |
+| French Southern Territories | TF           | EU868         | 868 MHz            | ✓              |
 
 ## G
 
-| Country           | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country           | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |-------------------|--------------|---------------|--------------------|----------------|
 | Gabon             | GA           | -             | <FreqExplanation/> | Not Supported  |
 | Gambia            | GM           | EU433         | <FreqExplanation/> | Not Supported  |
 | Gaza Strip        | PS           | -             | <FreqExplanation/> | Not Supported  |
-| Georgia           | GE           | EU868         | ✓                  | ✓              |
-| Germany           | DE           | EU868         | ✓                  | ✓              |
+| Georgia           | GE           | EU868         | 868 MHz            | ✓              |
+| Germany           | DE           | EU868         | 868 MHz            | ✓              |
 | Ghana             | GH           | EU433         | <FreqExplanation/> | Not Supported  |
-| Gibraltar         | GI           | EU868         | ✓                  | ✓              |
-| Greece            | GR           | EU868         | ✓                  | ✓              |
-| Greenland         | GL           | EU868         | ✓                  | ✓              |
-| Grenada           | GD           | AU915_SB1     | <FreqExplanation/> | ✓              |
-| Guadeloupe        | GP           | EU868         | ✓                  | ✓              |
-| Guam              | GU           | US915         | ✓                  | ✓              |
-| Guatemala         | GT           | AU915_SB1     | <FreqExplanation/> | ✓              |
-| Guernsey          | GG           | EU868         | ✓                  | ✓              |
+| Gibraltar         | GI           | EU868         | 868 MHz            | ✓              |
+| Greece            | GR           | EU868         | 868 MHz            | ✓              |
+| Greenland         | GL           | EU868         | 868 MHz            | ✓              |
+| Grenada           | GD           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Guadeloupe        | GP           | EU868         | 868 MHz            | ✓              |
+| Guam              | GU           | US915         | 915 MHz            | ✓              |
+| Guatemala         | GT           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Guernsey          | GG           | EU868         | 868 MHz            | ✓              |
 | Guinea            | GN           | EU433         | <FreqExplanation/> | Not Supported  |
 | Guinea-Bissau     | GW           | -             | <FreqExplanation/> | Not Supported  |
-| Guyana            | GY           | US915         | ✓                  | ✓              |
+| Guyana            | GY           | US915         | 915 MHz            | ✓              |
 
 ## H
 
-| Country                           | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country                           | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |-----------------------------------|--------------|---------------|--------------------|----------------|
 | Haiti                             | HT           | -             | <FreqExplanation/> | Not Supported  |
-| Heard Island and McDonald Islands | HM           | AU915_SB2     | <FreqExplanation/> | ✓              |
-| Honduras                          | HN           | AU915_SB1     | <FreqExplanation/> | ✓              |
-| Hong Kong                         | HK           | AS923_1       |  ✓                 | ✓              |
-| Hungary                           | HU           | EU868         | ✓                  | ✓              |
+| Heard Island and McDonald Islands | HM           | AU915_SB2     | 915 and 923 MHz    | ✓              |
+| Honduras                          | HN           | AU915_SB1     | 915 and 923 MHz    | ✓              |
+| Hong Kong                         | HK           | AS923_1       | 923 MHz            | ✓              |
+| Hungary                           | HU           | EU868         | 868 MHz            | ✓              |
 
 ## I
 
-| Country          | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2 |
+| Country          | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2 |
 |------------------|--------------|---------------|--------------------|-------|
-| Iceland          | IS           | EU868         | ✓                  | ✓     |
+| Iceland          | IS           | EU868         | 868 MHz            | ✓     |
 | India            | IN           | IN865         | <FreqExplanation/> | ✓     |
-| Indonesia        | ID           | AS923_2       | ✓                  | ✓     |
-| Iran             | IR           | EU868         | ✓                  | ✓     |
-| Iraq             | IQ           | EU868         | ✓                  | ✓     |
-| Ireland          | IE           | EU868         | ✓                  | ✓     |
-| Isle of Man      | IM           | EU868         | ✓                  | ✓     |
+| Indonesia        | ID           | AS923_2       | 923 MHz            | ✓     |
+| Iran             | IR           | EU868         | 868 MHz            | ✓     |
+| Iraq             | IQ           | EU868         | 868 MHz            | ✓     |
+| Ireland          | IE           | EU868         | 868 MHz            | ✓     |
+| Isle of Man      | IM           | EU868         | 868 MHz            | ✓     |
 | Israel           | IL           | AS923_4       | <FreqExplanation/> | ✓     |
-| Italy            | IT           | EU868         | ✓                  | ✓     |
+| Italy            | IT           | EU868         | 868 MHz            | ✓     |
 
 ## J
 
-| Country  | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2  |
+| Country  | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2  |
 |----------|--------------|---------------|--------------------|--------|
-| Jamaica  | JM           | AU915_SB1     | <FreqExplanation/> | ✓      |
-| Japan    | JP           | AS923_1       | ✓                  | ✓      |
-| Jersey   | JE           | EU868         | ✓                  | ✓      |
+| Jamaica  | JM           | AU915_SB1     | 915 and 923 MHz    | ✓      |
+| Japan    | JP           | AS923_1       | 923 MHz            | ✓      |
+| Jersey   | JE           | EU868         | 868 MHz            | ✓      |
 | Jordan   | JO           | IN865         | ✓                  | ✓      |
 
 ## K
 
-| Country    | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country    | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |------------|--------------|---------------|--------------------|----------------|
 | Kazakhstan | KZ           | IN865         | <FreqExplanation/> | ✓              |
-| Kenya      | KE           | EU868         | ✓                  | ✓              |
+| Kenya      | KE           | EU868         | 868 MHz            | ✓              |
 | Kiribati   | KI           | -             | <FreqExplanation/> | Not Supported  |
-| Kosovo     | XK           | EU868         | ✓                  | ✓              |
-| Kuwait     | KW           | EU868         | ✓                  | ✓              |
+| Kosovo     | XK           | EU868         | 868 MHz            | ✓              |
+| Kuwait     | KW           | EU868         | 868 MHz            | ✓              |
 | Kyrgyzstan | KG           | -             | <FreqExplanation/> | Not Supported  |
 
 ## L
 
-| Country          | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country          | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |------------------|--------------|---------------|--------------------|----------------|
-| Laos             | LA           | AS923_1       | ✓                  | ✓              |
-| Latvia           | LV           | EU868         | ✓                  | ✓              |
-| Lebanon          | LB           | EU868         | ✓                  | ✓              |
+| Laos             | LA           | AS923_1       | 923 MHz            | ✓              |
+| Latvia           | LV           | EU868         | 868 MHz            | ✓              |
+| Lebanon          | LB           | EU868         | 868 MHz            | ✓              |
 | Lesotho          | LS           | EU433         | <FreqExplanation/> | Not Supported  |
 | Liberia          | LR           | -             | <FreqExplanation/> | Not Supported  |
 | Libya            | LY           | -             | <FreqExplanation/> | Not Supported  |
-| Liechtenstein    | LI           | EU868         | ✓                  | ✓              |
-| Lithuania        | LT           | EU868         | ✓                  | ✓              |
-| Luxembourg       | LU           | EU868         | ✓                  | ✓              |
+| Liechtenstein    | LI           | EU868         | 868 MHz            | ✓              |
+| Lithuania        | LT           | EU868         | 868 MHz            | ✓              |
+| Luxembourg       | LU           | EU868         | 868 MHz            | ✓              |
 
 ## M
 
-| Country            | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2          |
+| Country            | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2          |
 |--------------------|--------------|---------------|--------------------|----------------|
-| Macau              | MO           | AS923_1       |  ✓                 | ✓              |
-| North Macedonia    | MK           | EU868         | ✓                  | ✓              |
-| Madagascar         | MG           | EU868         | ✓                  | ✓              |
+| Macau              | MO           | AS923_1       | 923 MHz            | ✓              |
+| North Macedonia    | MK           | EU868         | 868 MHz            | ✓              |
+| Madagascar         | MG           | EU868         | 868 MHz            | ✓              |
 | Malawi             | MW           | -             | <FreqExplanation/> | Not Supported  |
-| Malaysia           | MY           | AS923_1B      |  ✓                 | ✓              |
+| Malaysia           | MY           | AS923_1B      | 923 MHz            | ✓              |
 | Maldives           | MV           | -             | <FreqExplanation/> | Not Supported  |
 | Mali               | ML           | EU433         | <FreqExplanation/> | Not Supported  |
-| Malta              | MT           | EU868         | ✓                  | ✓              |
+| Malta              | MT           | EU868         | 868 MHz            | ✓              |
 | Marshall Islands   | MH           | -             | <FreqExplanation/> | Not Supported  |
-| Martinique         | MQ           | EU868         | ✓                  | ✓              |
-| Mauritania         | MR           | EU868         | ✓                  | ✓              |
+| Martinique         | MQ           | EU868         | 868 MHz            | ✓              |
+| Mauritania         | MR           | EU868         | 868 MHz            | ✓              |
 | Mauritius          | MU           | EU433         | <FreqExplanation/> | Not Supported  |
-| Mayotte            | YT           | EU868         | ✓                  | ✓              |
-| Mexico             | MX           | US915         | ✓                  | ✓              |
+| Mayotte            | YT           | EU868         | 868 MHz            | ✓              |
+| Mexico             | MX           | US915         | 915 MHz            | ✓              |
 | Micronesia         | FM           | -             | <FreqExplanation/> | Not Supported  |
-| Moldova            | MD           | EU868         | ✓                  | ✓              |
-| Monaco             | MC           | EU868         | ✓                  | ✓              |
+| Moldova            | MD           | EU868         | 868 MHz            | ✓              |
+| Monaco             | MC           | EU868         | 868 MHz            | ✓              |
 | Mongolia           | MN           | -             | <FreqExplanation/> | Not Supported  |
-| Montenegro         | ME           | EU868         | ✓                  | ✓              |
-| Montserrat         | MS           | AU915_SB1     | <FreqExplanation/> | ✓              |
+| Montenegro         | ME           | EU868         | 868 MHz            | ✓              |
+| Montserrat         | MS           | AU915_SB1     | 915 and 923 MHz    | ✓              |
 | Morocco            | MA           | EU433         | <FreqExplanation/> | Not Supported  |
 | Mozambique         | MZ           | -             | <FreqExplanation/> | Not Supported  |
-| Myanmar            | MM           | AS923_1       | ✓                  | ✓              |
+| Myanmar            | MM           | AS923_1       | 923 MHz            | ✓              |
 
 ## N
 
-| Country                  | Country Code | ISM Frequency | D1/M5/Pulse          | H1/H2          |
+| Country                  | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |--------------------------|--------------|---------------|----------------------|----------------|
-| Namibia                  | NA           | EU868         | ✓                    | ✓              |
+| Namibia                  | NA           | EU868         | 868 MHz                    | ✓              |
 | Nauru                    | NR           | -             | <FreqExplanation/>   | Not Supported  |
 | Nepal                    | NP           | -             | <FreqExplanation/>   | Not Supported  |
-| Netherlands              | NL           | EU868         | ✓                    | ✓              |
-| Netherlands Antilles     | AN           | EU868         | ✓                    | ✓              |
-| New Caledonia            | NC           | EU868         | ✓                    | ✓              |
-| New Zealand              | NZ           | AS923_1C      | <FreqExplanation/>   | ✓              |
-| Nicaragua                | NI           | AU915_SB1     | <FreqExplanation/>   | ✓              |
+| Netherlands              | NL           | EU868         | 868 MHz              | ✓              |
+| Netherlands Antilles     | AN           | EU868         | 868 MHz              | ✓              |
+| New Caledonia            | NC           | EU868         | 868 MHz              | ✓              |
+| New Zealand              | NZ           | AS923_1C      | 915 and 923 MHz      | ✓              |
+| Nicaragua                | NI           | AU915_SB1     | 915 and 923 MHz      | ✓              |
 | Niger                    | NE           | IN865         | <FreqExplanation/>   | ✓              |
-| Nigeria                  | NG           | EU868         | ✓                    | ✓              |
-| Niue                     | NU           | AS923_1       | <FreqExplanation/>   | ✓              |
-| Norfolk Island           | NF           | AU915_SB2     | <FreqExplanation/>   | ✓              |
+| Nigeria                  | NG           | EU868         | 868 MHz              | ✓              |
+| Niue                     | NU           | AS923_1       | 915 and 923 MHz      | ✓              |
+| Norfolk Island           | NF           | AU915_SB2     | 915 and 923 MHz      | ✓              |
 | North Korea              | KP           | -             | <FreqExplanation/>   | Not Supported  |
-| Northern Mariana Islands | MP           | US915         | ✓                    | ✓              |
-| Norway                   | NO           | EU868         | ✓                    | ✓              |
+| Northern Mariana Islands | MP           | US915         | 915 MHz              | ✓              |
+| Norway                   | NO           | EU868         | 868 MHz              | ✓              |
 
 ## O
 
-| Country  | Country Code | ISM Frequency | D1/M5/Pulse | H1/H2 |
+| Country  | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2 |
 |----------|--------------|---------------|-------------|-------|
-| Oman     | OM           | EU868         | ✓           | ✓     |
+| Oman     | OM           | EU868         | 868 MHz     | ✓     |
 
 ## P
 
-| Country                 | Country Code | ISM Frequency | D1/M5/Pulse          | H1/H2          |
+| Country                 | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |-------------------------|--------------|---------------|----------------------|----------------|
 | Pakistan                | PK           | AS923         |✓                     | ✓              |
 | Palau                   | PW           | -             | <FreqExplanation/>   | Not Supported  |
 | Palestinian Territories | PS           | -             | <FreqExplanation/>   | Not Supported  |
-| Panama                  | PA           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Papua New Guinea        | PG           | AS923_1       | <FreqExplanation/>   | ✓              |
-| Paraguay                | PY           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Peru                    | PE           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Philippines             | PH           | AS923_3       | <FreqExplanation/>   | ✓              |
+| Panama                  | PA           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Papua New Guinea        | PG           | AS923_1       | 915 and 923 MHz      | ✓              |
+| Paraguay                | PY           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Peru                    | PE           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Philippines             | PH           | AS923_3       | 915 MHz              | ✓              |
 | Pitcairn Islands        | PN           | -             | <FreqExplanation/>   | Not Supported  |
-| Poland                  | PL           | EU868         | ✓                    | ✓              |
-| Portugal                | PT           | EU868         | ✓                    | ✓              |
-| Puerto Rico             | PR           | US915         | ✓                    | ✓              |
+| Poland                  | PL           | EU868         | 868 MHz              | ✓              |
+| Portugal                | PT           | EU868         | 868 MHz              | ✓              |
+| Puerto Rico             | PR           | US915         | 915 MHz              | ✓              |
 
 ## Q
 
-| Country | Country Code | ISM Frequency | D1/M5/Pulse | H1/H2 |
+| Country | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2 |
 |---------|--------------|---------------|-------------|-------|
-| Qatar   | QA           | EU868         | ✓           | ✓     |
+| Qatar   | QA           | EU868         | 868 MHz     | ✓     |
 
 ## R
 
-| Country            | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2 |
+| Country            | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2 |
 |--------------------|--------------|---------------|--------------------|-------|
-| Réunion            | RE           | EU868         | ✓                  | ✓     |
-| Romania            | RO           | EU868         | ✓                  | ✓     |
+| Réunion            | RE           | EU868         | 868 MHz            | ✓     |
+| Romania            | RO           | EU868         | 868 MHz            | ✓     |
 | Russia             | RU           | RU864         | <FreqExplanation/> | ✓     |
-| Rwanda             | RW           | EU868         | ✓                  | ✓     |
+| Rwanda             | RW           | EU868         | 868 MHz            | ✓     |
 
 ## S
 
-| Country                                  | Country Code | ISM Frequency | D1/M5/Pulse          | H1/H2          |
+| Country                                  | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |------------------------------------------|--------------|---------------|----------------------|----------------|
 | Sahrawi Arab Democratic Republic         | EH           | -             | <FreqExplanation/>   | Not Supported  |
-| Saint Barthelemy                         | BL           | EU868         | ✓                    | ✓              |
+| Saint Barthelemy                         | BL           | EU868         | 868 MHz                    | ✓              |
 | Saint Helena                             | SH           | -             | <FreqExplanation/>   | Not Supported  |
-| Saint Kitts and Nevis                    | KN           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Saint Lucia                              | LC           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Saint Martin                             | MF           | EU868         | ✓                    | ✓              |
-| Saint Pierre and Miquelon                | PM           | EU868         | ✓                    | ✓              |
-| Saint Vincent and the Grenadines         | VC           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Samoa                                    |              | EU868         | ✓                    | ✓              |
-| San Marino                               | SM           | EU868         | ✓                    | ✓              |
+| Saint Kitts and Nevis                    | KN           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Saint Lucia                              | LC           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Saint Martin                             | MF           | EU868         | 868 MHz              | ✓              |
+| Saint Pierre and Miquelon                | PM           | EU868         | 868 MHz              | ✓              |
+| Saint Vincent and the Grenadines         | VC           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Samoa                                    |              | EU868         | 868 MHz              | ✓              |
+| San Marino                               | SM           | EU868         | 868 MHz              | ✓              |
 | São Tomé and Príncipe                    | ST           | -             | <FreqExplanation/>   | Not Supported  |
-| Saudi Arabia                             | SA           | EU868         | ✓                    | ✓              |
-| Senegal                                  | SN           | EU868         | ✓                    | ✓              |
-| Serbia                                   | RS           | EU868         | ✓                    | ✓              |
+| Saudi Arabia                             | SA           | EU868         | 868 MHz              | ✓              |
+| Senegal                                  | SN           | EU868         | 868 MHz              | ✓              |
+| Serbia                                   | RS           | EU868         | 868 MHz              | ✓              |
 | Seychelles                               | SC           | EU433         | <FreqExplanation/>   | Not supported  |
-| Sierra Leone                             | SL           | EU868         | ✓                    | ✓              |
-| Singapore                                | SG           | AS923_1       | ✓                    | ✓              |
-| Slovakia                                 | SK           | EU868         | ✓                    | ✓              |
-| Slovenia                                 | SI           | EU868         | ✓                    | ✓              |
-| Solomon Islands                          | SB           | AS923_1       | ✓                    | ✓              |
-| Somalia                                  | SO           | EU868         | ✓                    | ✓              |
-| South Africa                             | ZA           | EU868         | ✓                    | ✓              |
-| South Georgia and the South Sandwich Islands | GS       | EU868         | ✓                    | ✓              |
+| Sierra Leone                             | SL           | EU868         | 868 MHz              | ✓              |
+| Singapore                                | SG           | AS923_1       | 923 MHz              | ✓              |
+| Slovakia                                 | SK           | EU868         | 868 MHz              | ✓              |
+| Slovenia                                 | SI           | EU868         | 868 MHz              | ✓              |
+| Solomon Islands                          | SB           | AS923_1       | 923 MHz              | ✓              |
+| Somalia                                  | SO           | EU868         | 868 MHz              | ✓              |
+| South Africa                             | ZA           | EU868         | 868 MHz              | ✓              |
+| South Georgia and the South Sandwich Islands | GS       | EU868         | 868 MHz              | ✓              |
 | South Korea                              | KR           | KR920         | <FreqExplanation/>   | ✓              |
 | South Sudan                              | SS           | -             | <FreqExplanation/>   | Not Supported  |
-| Spain                                    | ES           | EU868         | ✓                    | ✓              |
-| Sri Lanka                                | LK           | AS923_1       | ✓                    | ✓              |
+| Spain                                    | ES           | EU868         | 868 MHz              | ✓              |
+| Sri Lanka                                | LK           | AS923_1       | 923 MHz              | ✓              |
 | Sudan                                    | SD           | -             | <FreqExplanation/>   | Not Supported  |
-| Suriname                                 | SR           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Svalbard and Jan Mayen                   | SJ           | EU868         | ✓                    | ✓              |
-| Sweden                                   | SE           | EU868         | ✓                    | ✓              |
-| Switzerland                              | CH           | EU868         | ✓                    | ✓              |
-| Syria                                    | SY           | EU868         | ✓                    | ✓              |
+| Suriname                                 | SR           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Svalbard and Jan Mayen                   | SJ           | EU868         | 868 MHz              | ✓              |
+| Sweden                                   | SE           | EU868         | 868 MHz              | ✓              |
+| Switzerland                              | CH           | EU868         | 868 MHz              | ✓              |
+| Syria                                    | SY           | EU868         | 868 MHz              | ✓              |
 
 ## T
 
-| Country                  | Country Code | ISM Frequency | D1/M5/Pulse          | H1/H2          |
+| Country                  | Country Code | ISM Frequency | D1/M5/Pulse version          | H1/H2          |
 |--------------------------|--------------|---------------|----------------------|----------------|
-| Taiwan                   | TW           | AS923_1       | ✓                    | ✓              |
+| Taiwan                   | TW           | AS923_1       | 923 MHz              | ✓              |
 | Tajikistan               | TJ           | -             | <FreqExplanation/>   | Not Supported  |
-| Tanzania                 | TZ           | AS923_1       | ✓                    | ✓              |
-| Thailand                 | TH           | AS923_1       | ✓                    | ✓              |
+| Tanzania                 | TZ           | AS923_1       | 923 MHz              | ✓              |
+| Thailand                 | TH           | AS923_1       | 923 MHz              | ✓              |
 | Timor-Leste              | TL           | -             | <FreqExplanation/>   | Not Supported  |
 | Togo                     | TG           | EU433         | <FreqExplanation/>   | Not supported  |
-| Tokelau                  | TK           | AS923_1       | <FreqExplanation/>   | ✓              |
-| Tonga                    | TO           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Trinidad and Tobago      | TT           | AU915_SB1     | <FreqExplanation/>   | ✓              |
-| Tunisia                  | TN           | EU868         | ✓                    | ✓              |
-| Turkey                   | TR           | EU868         | ✓                    | ✓              |
+| Tokelau                  | TK           | AS923_1       | 923 MHz              | ✓              |
+| Tonga                    | TO           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Trinidad and Tobago      | TT           | AU915_SB1     | 915 and 923 MHz      | ✓              |
+| Tunisia                  | TN           | EU868         | 868 MHz              | ✓              |
+| Turkey                   | TR           | EU868         | 868 MHz              | ✓              |
 | Turkmenistan             | TM           | -             | <FreqExplanation/>   | Not Supported  |
-| Turks and Caicos Islands | TC           | AU915_SB1     | <FreqExplanation/>   | ✓              |
+| Turks and Caicos Islands | TC           | AU915_SB1     | 915 and 923 MHz      | ✓              |
 | Tuvalu                   | TV           | -             | <FreqExplanation/>   | Not Supported  |
 
 ## U
 
-| Country                     | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2         |
+| Country                     | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |-----------------------------|--------------|---------------|--------------------|---------------|
-| U.S. Minor Outlying Islands | UM           | US915         | ✓                  | ✓             |
-| U.S. Virgin Islands         | VI           | US915         | ✓                  | ✓             |
-| Uganda                      | UG           | AS923_1       | ✓                  | ✓             |
-| Ukraine                     | UA           | EU868         | ✓                  | ✓             |
-| United Arab Emirates        | AE           | EU868         | ✓                  | ✓             |
-| United Kingdom              | GB           | EU868         | ✓                  | ✓             |
-| United States               | US           | US915         | ✓                  | ✓             |
-| Uruguay                     | UY           | AU915_SB1     | <FreqExplanation/> | ✓             |
+| U.S. Minor Outlying Islands | UM           | US915         | 915 MHz            | ✓             |
+| U.S. Virgin Islands         | VI           | US915         | 915 MHz            | ✓             |
+| Uganda                      | UG           | AS923_1       | 923 MHz            | ✓             |
+| Ukraine                     | UA           | EU868         | 868 MHz            | ✓             |
+| United Arab Emirates        | AE           | EU868         | 868 MHz            | ✓             |
+| United Kingdom              | GB           | EU868         | 868 MHz            | ✓             |
+| United States               | US           | US915         | 915 MHz            | ✓             |
+| Uruguay                     | UY           | AU915_SB1     | 915 and 923 MHz    | ✓             |
 | Uzbekistan                  | UZ           | EU433         | <FreqExplanation/> | Not supported |
 
 ## V
 
-| Country             | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2 |
+| Country             | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2 |
 |---------------------|--------------|---------------|--------------------|-------|
-| Vanuatu             | VU           | AS923_3       | <FreqExplanation/> | ✓     |
-| Vatican City        | VA           | EU868         | ✓                  | ✓     |
-| Venezuela           | VE           | AS923_1       |✓                   | ✓     |
-| Vietnam             | VN           | AS923_2       | <FreqExplanation/> | ✓     |
-| Virgin Islands (UK) | VG           | AU915_SB1     | <FreqExplanation/> | ✓     |
+| Vanuatu             | VU           | AS923_3       | 915 MHz            | ✓     |
+| Vatican City        | VA           | EU868         | 868 MHz            | ✓     |
+| Venezuela           | VE           | AS923_1       | 923 MHz            | ✓     |
+| Vietnam             | VN           | AS923_2       | 923 MHz            | ✓     |
+| Virgin Islands (UK) | VG           | AU915_SB1     | 915 and 923 MHz    | ✓     |
 
 ## W
 
-| Country           | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2         |
+| Country           | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |-------------------|--------------|---------------|--------------------|---------------|
-| Wallis and Futuna | WF           | EU868         | ✓                  | ✓             |
+| Wallis and Futuna | WF           | EU868         | 868 MHz            | ✓             |
 | Western Sahara    | EH           | -             | <FreqExplanation/> | Not Supported |
 
 ## Y
 
-| Country    | Country Code | ISM Frequency | D1/M5/Pulse        | H1/H2         |
+| Country    | Country Code | ISM Frequency | D1/M5/Pulse version        | H1/H2         |
 |------------|--------------|---------------|--------------------|---------------|
 | Yemen      | YE           | -             | <FreqExplanation/> | Not Supported |
 
 ## Z
 
-| Country  | Country Code | ISM Frequency | D1/M5/Pulse | H1/H2 |
+| Country  | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2 |
 |----------|--------------|---------------|-------------|-------|
-| Zambia   | ZM           | EU868         | ✓           | ✓     |
-| Zimbabwe | ZW           | EU868         | ✓           | ✓     |
+| Zambia   | ZM           | EU868         | 868 MHz           | ✓     |
+| Zimbabwe | ZW           | EU868         | 868 MHz           | ✓     |
 
 
 :::info

--- a/docs/wxm-devices/frequency-plans.mdx
+++ b/docs/wxm-devices/frequency-plans.mdx
@@ -14,6 +14,8 @@ country's regulations and use the appropriate frequency. You can find the respec
 regulatory body for each country in the list [here](https://en.wikipedia.org/wiki/List_of_telecommunications_regulatory_bodies#By_country).
 :::
 
+Source: [LoRa-Alliance Regional Parameters](https://lora-alliance.org/wp-content/uploads/2020/11/RP_2-1.0.2.pdf)
+
 ## A
 
 | Country            | Country Code | ISM Frequency | D1/M5/Pulse version | H1/H2        |


### PR DESCRIPTION
Added 923 MHz support, updated other countries according to LoRa Alliance doc.
Updated freq table to include actual freq user needs sto choose for each country when buying a station. 