### PR TITLE
Automatically assign reviewer on PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,3 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
-    reviewers:
-      - "PavlosTze"

--- a/.github/workflows/on-assign-reviewer-pr.yml
+++ b/.github/workflows/on-assign-reviewer-pr.yml
@@ -1,0 +1,21 @@
+name: Auto-assign PR Reviewer
+
+on:
+    pull_request:
+        types: [ opened, reopened ]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        if: github.actor != 'pavlostze'
+        steps:
+            -   name: Assign pavlostze as the PR reviewer
+                uses: actions/github-script@v7
+                with:
+                    script: |
+                        github.rest.pulls.requestReviewers({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          pull_number: context.payload.pull_request.number,
+                          reviewers: ['pavlostze']
+                        });


### PR DESCRIPTION
### **Why?**
Dependabot drops support for reviewers configuration option.

### **How?**
Created a new workflow that automatically assigns me as a reviewer on the PRs that I'm not the author (e.g. Dependabot or any community ones).

### **Testing**
Not testable atm as it needs to be merged on main.
